### PR TITLE
Added a fix for the sporadic in-editor crashes to the example script

### DIFF
--- a/FileDragAndDrop.cs
+++ b/FileDragAndDrop.cs
@@ -1,14 +1,34 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 using B83.Win32;
-
+using UnityEngine.Events;
 
 public class FileDragAndDrop : MonoBehaviour
 {
+
+    public UnityEventFileDropInfo OnFilesDropped;
+
+    Queue<FileDropInfo> importQueue = new Queue<FileDropInfo>();
+
+    void QueueFiles(List<string> files, POINT point)
+    {
+        importQueue.Enqueue(new FileDropInfo(files, point));
+    }
+
+    void LateUpdate()
+    {
+        if (importQueue.Count > 0)
+        {
+            var files = importQueue.Dequeue();
+            OnFilesDropped.Invoke(files);
+        }
+    }
+
     // important to keep the instance alive while the hook is active.
     UnityDragAndDropHook hook;
-    void OnEnable ()
+    void OnEnable()
     {
         // must be created on the main thread to get the right thread id.
         hook = new UnityDragAndDropHook();
@@ -24,7 +44,26 @@ public class FileDragAndDrop : MonoBehaviour
     {
         // do something with the dropped file names. aPos will contain the 
         // mouse position within the window where the files has been dropped.
-        Debug.Log("Dropped "+aFiles.Count+" files at: " + aPos + "\n"+
-            aFiles.Aggregate((a, b) => a + "\n" + b));
+        Debug.Log("Dropped " + aFiles.Count + " files at: " + aPos + "\n" +
+                  aFiles.Aggregate((a, b) => a + "\n" + b));
+        QueueFiles(aFiles, aPos);
+    }
+
+    [Serializable]
+    public class FileDropInfo
+    {
+        public List<string> Files { get; private set; }
+        public POINT Point { get; private set; }
+
+        public FileDropInfo(List<string> files, POINT point)
+        {
+            Files = files;
+            Point = point;
+        }
+    }
+
+    [Serializable]
+    public class UnityEventFileDropInfo : UnityEvent<FileDropInfo>
+    {
     }
 }


### PR DESCRIPTION
Crashes seemed to be related to the time the file handling takes inside the managed callback.
By delaying that and using a unity callback (LateUpdate in this example) it no longer crashes.