### PR TITLE
Enabled hook inside the Unity Editor

### DIFF
--- a/B83.Win32.cs
+++ b/B83.Win32.cs
@@ -430,7 +430,6 @@ namespace B83.Win32
 #if UNITY_EDITOR_WIN
         private static EditorWindow m_gameView;
         private const int shiftGetwindowRect = 8; // GetWindowRect Value is shift(This value is different in windows settings or display resolution)
-        private const int editorTitleMenuUnityToolBarHeight = 73;
 #endif
         // attribute required for IL2CPP, also has to be a static method
         [AOT.MonoPInvokeCallback(typeof(EnumThreadDelegate))]
@@ -476,19 +475,22 @@ namespace B83.Win32
                 WinAPI.DragQueryPoint(lParam.wParam, out pos);
 
 #if UNITY_EDITOR_WIN
-                // Check Drop point is in Game View
                 RECT editorWindowRect;
                 bool isSuccess = Window.GetWindowRect(mainWindow, out editorWindowRect);
                 if (isSuccess)
                 {
+                    // Check Drop point is in Game View
                     UnityEngine.Rect gameVewRectInEditor = m_gameView.position;
                     gameVewRectInEditor.x -= editorWindowRect.Left + shiftGetwindowRect;
-                    gameVewRectInEditor.y -=
-                        editorWindowRect.Top + shiftGetwindowRect + editorTitleMenuUnityToolBarHeight;
+                    gameVewRectInEditor.y -= editorWindowRect.Top + shiftGetwindowRect;
                     if (!gameVewRectInEditor.Contains(new UnityEngine.Vector2(pos.x, pos.y)))
                     {
                         return WinAPI.CallNextHookEx(m_Hook, code, wParam, ref lParam);
                     }
+
+                    // Convert Drop position to GameView Coordinate
+                    pos.x = pos.x - (int)gameVewRectInEditor.x;
+                    pos.y = pos.y - (int)gameVewRectInEditor.y;
                 }
 #endif
                 // 0xFFFFFFFF as index makes the method return the number of files

--- a/README.md
+++ b/README.md
@@ -4,5 +4,3 @@ Adds file drag and drop support for Unity standalone builds on windows.
 It uses the GetMessage hook to intercept the WM_DROPFILES message
 
 See the "FileDragAndDrop.cs" or "ImageExample.cs" file for an example usage.
-
-Due to too many issues in the Unity editor (causes random silent crashes) I have disabled the hook when tested in playmode inside the editor. So this feature only works in a build.


### PR DESCRIPTION
I discovered a cause of unity editor crash bug. 
In unity editor, some times drag and drop file event does not have any file path.
So, I added file path count check.

And in unity editor, I added feature that OnDroppedFiles function invoke only in game view window.

I confirmed this in Unity 2019.3.0f6 and 2018.4.3f1.